### PR TITLE
NEW: Added a callback before writing the record for the first time

### DIFF
--- a/code/GridFieldBulkImageUpload_Request.php
+++ b/code/GridFieldBulkImageUpload_Request.php
@@ -264,6 +264,9 @@ class GridFieldBulkImageUpload_Request extends RequestHandler {
 		
 		$record = Object::create($recordClass);
 		$record->setField($recordForeignKey, $recordForeignID);
+		// passes the current gridfield-instance to a call-back method on the new object
+		$record->extend("onBulkImageUpload", $this->gridField);
+		
 		$record->write();
 		
 		$upload = new Upload();		


### PR DESCRIPTION
This allows a DataObject to execute further code that depends on the current GridField-State, example. Set a ID to the value of the parent record:

``` php
public function onBulkImageUpload(GridField $gridField)
{
    $this->setField("ParentID", $gridField->getForm()->getRecord()->getField("ID"));
}
```

Best regards,
s-m
