### PR TITLE
Update GridFieldBulkImageUpload_Request.php

### DIFF
--- a/code/GridFieldBulkImageUpload_Request.php
+++ b/code/GridFieldBulkImageUpload_Request.php
@@ -40,7 +40,7 @@ class GridFieldBulkImageUpload_Request extends RequestHandler {
 	/**
 	 *
 	 */
-	static $url_handlers = array(
+	private static $url_handlers = array(
 		'$Action!' => '$Action'
 	);
 	


### PR DESCRIPTION
Silverstripe 3.1.0 requires statics to be defined as private

http://doc.silverstripe.org/framework/en/3.1/changelogs/3.1.0
