### PR TITLE
Use populateCMSDataFields to return default DataObject values

### DIFF
--- a/code/GridFieldBulkImageUpload_Request.php
+++ b/code/GridFieldBulkImageUpload_Request.php
@@ -166,6 +166,7 @@ class GridFieldBulkImageUpload_Request extends RequestHandler {
 		if ( $config['imageFieldName'] == null ) $config['imageFieldName'] = $this->getDefaultRecordImageField();
 		
 		$recordCMSDataFields = GridFieldBulkEditingHelper::getModelFilteredDataFields($config, $recordCMSDataFields);
+		$recordCMSDataFields = GridFieldBulkEditingHelper::populateCMSDataFields($recordCMSDataFields, $this->gridField->list->dataClass, $recordID);
 		$formFieldsHTML = GridFieldBulkEditingHelper::dataFieldsToHTML($recordCMSDataFields);
 		$formFieldsHTML = GridFieldBulkEditingHelper::escapeFormFieldsHTML($formFieldsHTML, $recordID);
 		


### PR DESCRIPTION
I have edited the getRecordHTMLFormFields method to run populateCMSDataFields so that default values set in your DataObject get pulled through.
