### PR TITLE
BUGFIX: Prevent FormField Description from being styled as nolabel

### DIFF
--- a/css/GridFieldBulkImageUpload.css
+++ b/css/GridFieldBulkImageUpload.css
@@ -63,3 +63,8 @@ li.ss-uploadfield-item.template-download .imgPreview
 {
 	color: #f25000;
 }
+
+#BulkImageUploadField .field .help
+{
+	margin: 4px 0 0 184px;
+}


### PR DESCRIPTION
If you add a field with a description to the edit form the description gets rendered in a span flush to the left. This is because BulkImageUploadField has the class nolabel. This is a simple fix to re-apply the standard styling.
