### PR TITLE
Fix button alignment in firefox

### DIFF
--- a/css/GridFieldBulkManager.css
+++ b/css/GridFieldBulkManager.css
@@ -27,6 +27,7 @@
 	margin: 0;
 
 	color: #000;
+	vertical-align: top;
 }
 
 .cms table.ss-gridfield-table tbody td a.tempDisabledEditLink


### PR DESCRIPTION
This fixes the button alignment of the Edit and Go buttons in Firefox.
