### PR TITLE
BulkUpload Response broken

### DIFF
--- a/code/GridFieldBulkImageUpload_Request.php
+++ b/code/GridFieldBulkImageUpload_Request.php
@@ -361,7 +361,8 @@ class GridFieldBulkImageUpload_Request extends RequestHandler {
 		$uploadResponse = Convert::json2array( $uploadResponse->getBody() );
 		$uploadResponse = array_shift( $uploadResponse );
 		$uploadedFile = DataObject::get_by_id( $this->getFileRelationClassName(), $uploadResponse['id'] );
-
+		$preview_url = $uploadedFile->setHeight(55)->Link();
+		
 		// Attach the file to record.				
 		$record->{"{$fileRelationName}ID"} = $uploadedFile->ID;					
 		$record->write();
@@ -374,7 +375,7 @@ class GridFieldBulkImageUpload_Request extends RequestHandler {
 		
 		// Collect all output data.
 		$return = array_merge($uploadResponse, array(
-			'preview_url' => $uploadedFile->setHeight(55)->Link(),
+			'preview_url' => $preview_url,
 			'record' => array(
 				'ID' => $record->ID,
 				'fields' => $recordEditableFormFields


### PR DESCRIPTION
I don't think this has always been a problem, but when I tested recently it was.
When I upload an image with the BulkUploader, it uploads just fine, but the ajax response is corrupted and the download bar turns red.

Investigating further I get

```
Fatal error: Call to a member function Link() on a non-object in C:\wamp\www\snwp_v31\GridFieldBulkEditingTools\code\GridFieldBulkImageUpload_Request.php on line 375

which is:
'preview_url' => $uploadedFile->setHeight(55)->Link(),
```

I noticed that if I move `$uploadedFile->setHeight(55)->Link()` to line 362 as the pull request shows, it seems to work just fine.
I have no idea why it is behaving this way, but this seems to have fixed it for me
