### PR TITLE
Updated requirements in composer.json to "~3.1" to support 3.1.0 stable.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,6 @@
     "url": "git@github.com:colymba/GridFieldBulkEditingTools.git"
   }],
 	"require": {
-    "silverstripe/framework": ">=3.1.x-dev,<4.0"
+    "silverstripe/framework": "~3.1"
 	}
 }


### PR DESCRIPTION
See https://groups.google.com/forum/#!topic/silverstripe-dev/kCHSHLZp2Yg
