### PR TITLE
addBulkAction improvement

### DIFF
--- a/code/GridFieldBulkManager.php
+++ b/code/GridFieldBulkManager.php
@@ -211,9 +211,9 @@ class GridFieldBulkManager implements GridField_HTMLProvider, GridField_ColumnPr
 		}
 		else{
 			$config = array(
-        'isAjax'        => true,
-        'icon'          => 'accept',
-        'isDestructive' => false
+				'isAjax'        => isset($config['isAjax']) ? $config['isAjax'] : true,
+				'icon'          => isset($config['icon']) ? $config['icon'] : 'accept',
+				'isDestructive' => isset($config['isDestructive']) ? $config['isDestructive'] : false
 			);
 		}
 


### PR DESCRIPTION
I've noticed when creating a custom action you can pass a custom config for it. In AddBulkActionFunction the config never takes effect as it's always defined without taking into consideration the parameters passed into the function.

Hope it makes sense to you. 

Regards,

daniel quilez
