### PR TITLE
fix update function when working with locale

### DIFF
--- a/bulkManager/code/GridFieldBulkActionEditHandler.php
+++ b/bulkManager/code/GridFieldBulkActionEditHandler.php
@@ -250,6 +250,7 @@ class GridFieldBulkActionEditHandler extends GridFieldBulkActionHandler
 
 		if ( isset($data['url']) ) unset($data['url']);
 		if ( isset($data['cacheBuster']) ) unset($data['cacheBuster']);
+		if ( isset($data['locale']) ) unset($data['locale']);
 
 		foreach ($data as $recordID => $recordDataSet)
 		{


### PR DESCRIPTION
When using a localized page in order of prevent errors when iterating through records id we need to remove locale attributes same as we do with url and cacheBuster.
