### PR TITLE
display edit all only when the action is enabled.

### DIFF
--- a/bulkUpload/code/GridFieldBulkUpload.php
+++ b/bulkUpload/code/GridFieldBulkUpload.php
@@ -232,11 +232,17 @@ class GridFieldBulkUpload implements GridField_HTMLProvider, GridField_URLHandle
 				->setAttribute('data-url', $gridField->Link('bulkupload/cancel'))
 				->setUseButtonTag(true);			
 
-			$editAllButton = FormAction::create('EditAll', _t('GRIDFIELD_BULK_UPLOAD.EDIT_ALL_BTN_LABEL', 'Edit all'))
-					->addExtraClass('bulkUploadEditButton')
-					->setAttribute('data-icon', 'pencil')
-					->setAttribute('data-url', $gridField->Link('bulkupload/edit'))
-					->setUseButtonTag(true);
+			$bulkManager_config = $bulkManager->first()->getConfig();
+			$bulkManager_actions = $bulkManager_config['actions'];
+			if(array_key_exists('bulkedit' , $bulkManager_actions)){
+				$editAllButton = FormAction::create('EditAll', _t('GRIDFIELD_BULK_UPLOAD.EDIT_ALL_BTN_LABEL', 'Edit all'))
+                                        ->addExtraClass('bulkUploadEditButton')
+                                        ->setAttribute('data-icon', 'pencil')
+                                        ->setAttribute('data-url', $gridField->Link('bulkupload/edit'))
+                                        ->setUseButtonTag(true);
+			}else{
+				$editAllButton = '';
+			}
 		}
 		else{
 			$cancelButton = '';


### PR DESCRIPTION
in BulkUpload when using a BulkManager we should only display edit all possibility when we have it defined in our actions of BulkManager.
