### PR TITLE
DOCS remove param $editableFields from PHPDoc

### DIFF
--- a/bulkUpload/code/GridFieldBulkUpload.php
+++ b/bulkUpload/code/GridFieldBulkUpload.php
@@ -29,7 +29,6 @@ class GridFieldBulkUpload implements GridField_HTMLProvider, GridField_URLHandle
 	 * Component constructor
 	 * 
 	 * @param string $fileRelationName
-	 * @param string/array $editableFields
 	 */
 	public function __construct($fileRelationName = null)
 	{		


### PR DESCRIPTION
parameter no longer exists
