### PR TITLE
ENHANCEMENT: Use File->Title to set default Title

### DIFF
--- a/bulkUpload/code/GridFieldBulkUpload_Request.php
+++ b/bulkUpload/code/GridFieldBulkUpload_Request.php
@@ -156,15 +156,13 @@ class GridFieldBulkUpload_Request extends RequestHandler
 			$title = $record->getTitle();
 			if ( !$title || $title === $record->ID )
 			{
-				$title = basename($uploadedFile->getFilename());
-
 				if ( $record->hasDatabaseField('Title') )
 				{
-					$record->Title = $title;
+					$record->Title = $uploadedFile->Title;
 					$record->write();
 				}
 				else if ($record->hasDatabaseField('Name')){
-					$record->Name = $title;
+					$record->Name = $uploadedFile->Title;
 					$record->write();
 				}
 			}


### PR DESCRIPTION
Use `$uploadedFile->Title` when setting the records default Title as it gives a much nicer output than `basename($uploadedFile->getFilename())`

For example `My nicely named file` instead of `My-nicely-named-file.jpg`
