### PR TITLE
Set Content-Type to 'application/json' for wildcard HTTP_ACCEPT

### DIFF
--- a/bulkUpload/code/GridFieldBulkUpload_Request.php
+++ b/bulkUpload/code/GridFieldBulkUpload_Request.php
@@ -295,7 +295,7 @@ class GridFieldBulkUpload_Request extends RequestHandler
 	 */
 	protected function contentTypeNegotiation(&$response)
 	{
-		if (isset($_SERVER['HTTP_ACCEPT']) && (strpos($_SERVER['HTTP_ACCEPT'], 'application/json') !== false))
+		if (isset($_SERVER['HTTP_ACCEPT']) && ((strpos($_SERVER['HTTP_ACCEPT'], 'application/json') !== false) || $_SERVER['HTTP_ACCEPT'] === '*/*' )) {
 		{
 			$response->addHeader('Content-Type', 'application/json');
 		}else{


### PR DESCRIPTION
The Content-Type HTTP header should be set to application/json if HTTP_ACCEPT has application/json or is _/_
