### PR TITLE
Fix broken en.yml file

### DIFF
--- a/lang/en.yml
+++ b/lang/en.yml
@@ -20,4 +20,4 @@ en:
     TOGGLE_ALL_LINK: Show/Hide all
     SAVE_BTN_LABEL: Save all
     CANCEL_BTN_LABEL: Cancel
-    SAVE_RESULT_TEXT: {count} {class} saved successfully.
+    SAVE_RESULT_TEXT: '{count} {class} saved successfully.'


### PR DESCRIPTION
I know I'm not meant to change this directly, but I suspect that this was the cause of this issue in the first place.

It'd be a bit easier to fix this if the .tx folder was available for localisation contributors. :)
