### PR TITLE
BUG: $dataFields needs to be indexed by the field name

### DIFF
--- a/bulkManager/code/GridFieldBulkActionEditHandler.php
+++ b/bulkManager/code/GridFieldBulkActionEditHandler.php
@@ -238,10 +238,7 @@ class GridFieldBulkActionEditHandler extends GridFieldBulkActionHandler
 
 			foreach ($editableFields as $fieldName)
 			{
-				array_push(
-					$dataFields,
-					$fields->dataFieldByName($fieldName)
-				);
+				$dataFields[$fieldName] = $fields->dataFieldByName($fieldName);
 			}
 		}
 		else{


### PR DESCRIPTION
When using editableFields, `$dataFields` currently gets numerically indexed, which breaks saving rather massively (all fields get wiped instead).
