### PR TITLE
Fixed problem with BulkEditingTools and Tabs in IE

### DIFF
--- a/bulkManager/javascript/GridFieldBulkManager.js
+++ b/bulkManager/javascript/GridFieldBulkManager.js
@@ -14,7 +14,6 @@
           		targets = ['.filter-header', '.sortable-header'],
           		$target = $parent.find(targets.join(',')),
 
-              $component = this.clone(),
               index = $tr.index(this),
               newIndex = $tr.length - 1
               ;
@@ -29,9 +28,8 @@
 
           if ( index > newIndex )
           {
-            $component.insertBefore($tr.eq(newIndex));
-            this.remove();
-          }          
+            $tr.eq(newIndex).insertAfter($(this));
+          }
         },
         onunmatch: function(){}
       });


### PR DESCRIPTION
When GridFieldBulkEditingTools are used on GridField within Form Tab, Internet
Explorer (11) has problems switching to another Form Tab. In this case, clicking
on different tab has no effect, one must at first click somewhere else on the
page, and only after that it's possible to change the tab. While debugging, I
found out that the reason of this behavior is cloning, moving and removing of
the tr with the bulk manager options. Without cloning and removing, and moving
the tr with filter header or sortable header instead of tr with bulk manager
options, switching tabs works fine even in the IE 11.