### PR TITLE
Fix for 'From files' Button

### DIFF
--- a/bulkUpload/code/GridFieldBulkUpload_Request.php
+++ b/bulkUpload/code/GridFieldBulkUpload_Request.php
@@ -182,7 +182,7 @@ class GridFieldBulkUpload_Request extends RequestHandler
         */
         $uploadField = $this->getUploadField();
 
-        return UploadField_SelectHandler::create($this, $uploadField->getFolderName());
+        return UploadField_SelectHandler::create($uploadField, $uploadField->getFolderName());
     }
 
     /**


### PR DESCRIPTION
This was failing due to a method call that does not exist.  This is the suggested fix from https://github.com/colymba/GridFieldBulkEditingTools/pull/94