### PR TITLE
FIX Version constraint for asset-admin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "silverstripe/framework": "^4.0@dev",
-        "silverstripe/asset-admin": "^4.0@dev"
+        "silverstripe/asset-admin": "^1.0@dev"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
silverstripe/asset-admin doesn't share the same major versions as the framework, cms etc - it's in 1.0.0 alpha at the moment

cc @colymba 