### PR TITLE
API Install module into vendor folder, remove path constants and update resource references

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -1,8 +1,1 @@
 <?php
-//define global path to Components' root folder
-if (!defined('BULKEDITTOOLS_PATH')) {
-    $folder = rtrim(basename(dirname(__FILE__)));
-    define('BULKEDITTOOLS_PATH', $folder);
-    define('BULKEDITTOOLS_UPLOAD_PATH', $folder . '/bulkUpload');
-    define('BULKEDITTOOLS_MANAGER_PATH', $folder . '/bulkManager');
-}

--- a/bulkManager/code/BulkAction/EditHandler.php
+++ b/bulkManager/code/BulkAction/EditHandler.php
@@ -312,9 +312,9 @@ class EditHandler extends Handler
         $form->addExtraClass('center cms-content');
         $form->setAttribute('data-pjax-fragment', 'CurrentForm Content');
 
-        Requirements::javascript(BULKEDITTOOLS_MANAGER_PATH . '/javascript/GridFieldBulkEditingForm.js');
-        Requirements::css(BULKEDITTOOLS_MANAGER_PATH . '/css/GridFieldBulkEditingForm.css');
-        Requirements::add_i18n_javascript(BULKEDITTOOLS_PATH . '/lang/js');
+        Requirements::javascript('colymba/gridfield-bulk-editing-tools:bulkManager/javascript/GridFieldBulkEditingForm.js');
+        Requirements::css('colymba/gridfield-bulk-editing-tools:bulkManager/css/GridFieldBulkEditingForm.css');
+        Requirements::add_i18n_javascript('colymba/gridfield-bulk-editing-tools:lang/js');
 
         if ($this->request->isAjax()) {
             $response = new HTTPResponse(

--- a/bulkManager/code/BulkManager.php
+++ b/bulkManager/code/BulkManager.php
@@ -277,9 +277,9 @@ class BulkManager implements GridField_HTMLProvider, GridField_ColumnProvider, G
      */
     public function getHTMLFragments($gridField)
     {
-        Requirements::css(BULKEDITTOOLS_MANAGER_PATH . '/css/GridFieldBulkManager.css');
-        Requirements::javascript(BULKEDITTOOLS_MANAGER_PATH . '/javascript/GridFieldBulkManager.js');
-        Requirements::add_i18n_javascript(BULKEDITTOOLS_PATH . '/lang/js');
+        Requirements::css('colymba/gridfield-bulk-editing-tools:bulkManager/css/GridFieldBulkManager.css');
+        Requirements::javascript('colymba/gridfield-bulk-editing-tools:bulkManager/javascript/GridFieldBulkManager.js');
+        Requirements::add_i18n_javascript('colymba/gridfield-bulk-editing-tools:lang/js');
 
         if (!count($this->config['actions'])) {
             user_error('Trying to use GridFieldBulkManager without any bulk action.', E_USER_ERROR);

--- a/bulkUpload/code/BulkUploader.php
+++ b/bulkUpload/code/BulkUploader.php
@@ -427,9 +427,9 @@ class BulkUploader implements GridField_HTMLProvider, GridField_URLHandler
             'UploadField' => $uploadField->Field() // call ->Field() to get requirements in right order
         ));
 
-        Requirements::css(BULKEDITTOOLS_UPLOAD_PATH . '/css/GridFieldBulkUpload.css');
-        Requirements::javascript(BULKEDITTOOLS_UPLOAD_PATH . '/javascript/GridFieldBulkUpload.js');
-        Requirements::add_i18n_javascript(BULKEDITTOOLS_PATH . '/lang/js');
+        Requirements::css('colymba/gridfield-bulk-editing-tools:bulkUpload/css/GridFieldBulkUpload.css');
+        Requirements::javascript('colymba/gridfield-bulk-editing-tools:bulkUpload/javascript/GridFieldBulkUpload.js');
+        Requirements::add_i18n_javascript('colymba/gridfield-bulk-editing-tools:lang/js');
 
         return array(
             'header' => $data->renderWith('Colymba\\BulkUpload\\BulkUploader'),

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "colymba/gridfield-bulk-editing-tools",
-    "type": "silverstripe-module",
+    "type": "silverstripe-vendormodule",
     "description": "SilverStripe GridField component to upload images and edit records in bulk",
     "homepage": "https://github.com/colymba/GridFieldBulkEditingTools",
     "keywords": ["silverstripe", "bulk upload", "image upload", "gridfield bulk upload"],
@@ -16,13 +16,20 @@
         }
     ],
     "require": {
-        "silverstripe/framework": "^4.0@dev",
-        "silverstripe/asset-admin": "^1.0@dev"
+        "silverstripe/framework": "^4.0",
+        "silverstripe/asset-admin": "^1.0"
     },
     "extra": {
         "branch-alias": {
             "dev-master": "3.x-dev"
-        }
+        },
+        "expose": [
+            "bulkManager/css",
+            "bulkManager/javascript",
+            "bulkUpload/css",
+            "bulkUpload/javascript",
+            "lang"
+        ]
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This pull request changes the module type to a vendor module, which means Composer will install it into a project's vendor folder.

It also includes Composer configuration to "expose" the CSS and Javascript assets in the project's resources folder via symlinks, and updates the Requirements call references to use resolvable module path references instead of file paths relative to the project root.

This also removes the constants from \_config.php since they're no longer used.

Relevant issue: #160