### PR TITLE
FIX Use safer semver constraint for framework

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,6 @@
     "url": "git@github.com:colymba/GridFieldBulkEditingTools.git"
   }],
 	"require": {
-    "silverstripe/framework": ">=3.1"
+    "silverstripe/framework": "^3.1"
 	}
 }


### PR DESCRIPTION
\>=3.1 will match 4.0, so switching to use ^3.1 which won't.