### PR TITLE
Get current controller via curr()  (removes pushCurrent issue)

### DIFF
--- a/src/BulkManager/BulkManager.php
+++ b/src/BulkManager/BulkManager.php
@@ -16,6 +16,7 @@ use SilverStripe\Forms\GridField\GridField_URLHandler;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\View\ArrayData;
 use SilverStripe\View\Requirements;
+use SilverStripe\Control\Controller;
 
 /**
  * GridField component for editing attached models in bulk.
@@ -344,15 +345,13 @@ class BulkManager implements GridField_HTMLProvider, GridField_ColumnProvider, G
      */
     public function handleBulkAction($gridField, $request)
     {
-        $controller = $gridField->getForm()->getController();
-
+        $controller = Controller::curr();
         $actionUrlSegment = $request->shift();
         $handlerClass = $this->config['actions'][$actionUrlSegment];
 
         $controller->pushCurrent();
         $handler = Injector::inst()->create($handlerClass, $gridField, $this);
-        if ($handler)
-        {
+        if ($handler) {
             return $handler->handleRequest($request);
         }
 

--- a/src/BulkUploader/BulkUploader.php
+++ b/src/BulkUploader/BulkUploader.php
@@ -2,17 +2,18 @@
 
 namespace Colymba\BulkUpload;
 
-use Colymba\BulkUpload\BulkUploadHandler;
-use Colymba\BulkUpload\BulkUploadField;
-
-use SilverStripe\Core\Config\Config;
-use SilverStripe\Dev\Deprecation;
-use SilverStripe\Forms\FormAction;
-use SilverStripe\Forms\GridField\GridField_HTMLProvider;
-use SilverStripe\Forms\GridField\GridField_URLHandler;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\View\ArrayData;
+
+use SilverStripe\Dev\Deprecation;
+use SilverStripe\Forms\FormAction;
 use SilverStripe\View\Requirements;
+use SilverStripe\Control\Controller;
+use SilverStripe\Core\Config\Config;
+use Colymba\BulkUpload\BulkUploadField;
+use Colymba\BulkUpload\BulkUploadHandler;
+use SilverStripe\Forms\GridField\GridField_URLHandler;
+use SilverStripe\Forms\GridField\GridField_HTMLProvider;
 
 /**
  * GridField component for uploading images in bulk.
@@ -331,7 +332,8 @@ class BulkUploader implements GridField_HTMLProvider, GridField_URLHandler
      */
     public function handleBulkUpload($gridField, $request)
     {
-        $gridField->getForm()->getController()->pushCurrent();
+        $controller = Controller::curr();
+        $controller->pushCurrent();
         $handler = new \Colymba\BulkUpload\BulkUploadHandler($gridField, $this);
 
         return $handler->handleRequest($request);


### PR DESCRIPTION
Potential fix for #174 

I have tested this on `BulkManager` and it appears to work OK.

I have also added the patch to `BulkUploader`, but I don't use it. It might be worth testing if it works as expected?