### PR TITLE
Row updating broken in SilverStripe 4

### DIFF
--- a/src/BulkTools/HTTPBulkToolsResponse.php
+++ b/src/BulkTools/HTTPBulkToolsResponse.php
@@ -336,7 +336,7 @@ class HTTPBulkToolsResponse extends HTTPResponse
             );
 
             foreach ($this->successRecords as $record) {
-                $data = array('id' => $record->ID, 'class' => $record->ClassName);
+                $data = array('id' => $record->ID, 'class' => str_replace('\\', '\\\\', $record->ClassName));
                 if (!$this->removesRows) {
                     $data['row'] = $this->getRecordGridfieldRow($record);
                 }


### PR DESCRIPTION
Row updating is broken in SilverStripe 4 when for example using the PublishHandler or UnPublishHandler actions. This is due to unescaped backslashes in the fully qualified class name in json data, which when parsed in javascript treats the backslash as an escape character.
This can be fixed by escaping the backslash character in HTTPBulkToolsResponse.