### PR TITLE
FIX: asset-admin is a suggested, not required module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,9 @@
         }
     ],
     "require": {
-        "silverstripe/framework": "~4",
+        "silverstripe/framework": "~4"
+    },
+    "suggest": {
         "silverstripe/asset-admin": "~1"
     },
     "extra": {


### PR DESCRIPTION
This lets you install the module in apps that don’t have asset-admin
(such as ModelAdmin-focused apps, where batch editing would be handy)

Fixes #202.