### PR TITLE
fix undefined index notice

### DIFF
--- a/src/BulkTools/HTTPBulkToolsResponse.php
+++ b/src/BulkTools/HTTPBulkToolsResponse.php
@@ -346,7 +346,7 @@ class HTTPBulkToolsResponse extends HTTPResponse
             $body['records']['failed'] = $this->failedRecords;
         }
 
-        if (count($body['records']['success']) === 0) {
+        if (isset($body['records']['success']) && count($body['records']['success']) === 0) {
             $body['isWarning'] = true;
         }
 


### PR DESCRIPTION
$body['records'] is only defined if entering the if clause and therefore the count on line 349 can cause undefined index errors