### PR TITLE
FIX Handle symfony deprecation warning

### DIFF
--- a/src/BulkTools/HTTPBulkToolsResponse.php
+++ b/src/BulkTools/HTTPBulkToolsResponse.php
@@ -369,7 +369,7 @@ class HTTPBulkToolsResponse extends HTTPResponse
     public function shutdown()
     {
         $error = error_get_last();
-        if ($error !== null ) {
+        if ($error !== null && $error['type'] !== E_USER_DEPRECATED) {
             $this->setMessage($error['message']);
             $this->setStatusCode(500, $error['message']);
             $this->outputBody();


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/9955

The `error_get_last()` in the `shutdown()` function was causing an unrelated and otherwise harmless deprecation warning on a symfony component to break the upload field, including on environments which were set to 'live' which wouldn't otherwise give deprecation warnings.

