### PR TITLE
IMPR: Allow dot syntax UF Setup calls

### DIFF
--- a/src/BulkUploader/BulkUploader.php
+++ b/src/BulkUploader/BulkUploader.php
@@ -250,7 +250,15 @@ class BulkUploader implements GridField_HTMLProvider, GridField_URLHandler
 
         //UploadField setup
         foreach ($this->ufSetup as $fn => $param) {
-            $uploadField->{$fn}($param);
+            $funcs = explode('.', $fn);
+            $lastCall = array_pop($funcs);
+
+            $res = $uploadField;
+            foreach ($funcs as $call) {
+                $res = $res->{$call}();
+            }
+            
+            $res->{$lastCall}($param);
         }
 
         $schema['data']['createFileEndpoint'] = [


### PR DESCRIPTION
Example:
new BulkUploader()->setUfSetup('getValidator.setAllowedExtensions', ['jpg', 'jpeg', 'png', 'gif']);