### PR TITLE
FIX: onBulkUpload should be called before write to bypass validation

### DIFF
--- a/src/BulkUploader/BulkUploadHandler.php
+++ b/src/BulkUploader/BulkUploadHandler.php
@@ -80,9 +80,9 @@ class BulkUploadHandler extends RequestHandler
     {
         $recordClass = $this->component->getRecordClassName($this->gridField);
         $record = $recordClass::create();
-        $record->write();
-
+        
         $record->extend('onBulkUpload', $this->gridField);
+        $record->write();
 
         $fileRelationName = $this->component->getFileRelationName($this->gridField);
         $record->{"{$fileRelationName}ID"} = $fileID;

--- a/src/BulkUploader/BulkUploadHandler.php
+++ b/src/BulkUploader/BulkUploadHandler.php
@@ -82,10 +82,9 @@ class BulkUploadHandler extends RequestHandler
         $record = $recordClass::create();
         
         $record->extend('onBulkUpload', $this->gridField);
-        $record->write();
-
         $fileRelationName = $this->component->getFileRelationName($this->gridField);
         $record->{"{$fileRelationName}ID"} = $fileID;
+        
         $record->write(); //HasManyList call write on record but not ManyManyList, so we call it here again
         
         $this->gridField->list->add($record);

--- a/src/BulkUploader/BulkUploader.php
+++ b/src/BulkUploader/BulkUploader.php
@@ -250,7 +250,15 @@ class BulkUploader implements GridField_HTMLProvider, GridField_URLHandler
 
         //UploadField setup
         foreach ($this->ufSetup as $fn => $param) {
-            $uploadField->{$fn}($param);
+            $funcs = explode('.', $fn);
+            $lastCall = array_pop($funcs);
+
+            $res = $uploadField;
+            foreach ($funcs as $call) {
+                $res = $res->{$call}();
+            }
+
+            $res->{$lastCall}($param);
         }
 
         $schema['data']['createFileEndpoint'] = [


### PR DESCRIPTION
Some objects has required fields and object validation will fail on write()