### PR TITLE
DEP Update javascript dependencies

### DIFF
--- a/client/src/js/manager.js
+++ b/client/src/js/manager.js
@@ -30,7 +30,6 @@ jQuery.entwine('colymba', ($) => {
     },
   });
 
-
   /**
    * Bulkselect table cell behaviours
    */
@@ -91,7 +90,6 @@ jQuery.entwine('colymba', ($) => {
     }
   });
 
-
   /**
    * Bulk action dropdown behaviours
    */
@@ -129,7 +127,6 @@ jQuery.entwine('colymba', ($) => {
         $btn.find('img').remove();
       }
 
-
       if (config[value].destructive) {
         $btn.addClass('btn-outline-danger');
       } else {
@@ -137,7 +134,6 @@ jQuery.entwine('colymba', ($) => {
       }
     }
   });
-
 
   /**
    * bulk action button behaviours

--- a/client/src/js/managerBulkEditingForm.js
+++ b/client/src/js/managerBulkEditingForm.js
@@ -33,7 +33,6 @@ jQuery.entwine('colymba', ($) => {
     }
   });
 
-
   /**
    * Contains each rocrds editing fields,
    * tracks changes and updates...

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "core-js": "^3.26.0"
   },
   "devDependencies": {
-    "@silverstripe/eslint-config": "^1.0.0-alpha6",
-    "@silverstripe/webpack-config": "^2.0.0-alpha5",
+    "@silverstripe/eslint-config": "^1.0.0",
+    "@silverstripe/webpack-config": "^2.0.0",
     "webpack": "^5.74.0",
     "webpack-cli": "^5.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1261,10 +1261,10 @@
   resolved "https://registry.yarnpkg.com/@sect/modernizr-loader/-/modernizr-loader-1.0.3.tgz#7fd8cec372426c53f113f3cfd9344cb29e959825"
   integrity sha512-47zKwv4/1I0CYptZz8s4aSYSe0awmuyqa+HFKxN89/75h2q8hr6V752TZ9VjhGDhQ4gU0EU7Plew7b+7bf2crg==
 
-"@silverstripe/eslint-config@^1.0.0-alpha6":
-  version "1.0.0-alpha6"
-  resolved "https://registry.yarnpkg.com/@silverstripe/eslint-config/-/eslint-config-1.0.0-alpha6.tgz#1f243b003fddf3503a4abea37f35a8a5968cc96e"
-  integrity sha512-+P7UzhMRSmc7UlRYCiSXwjauLFYU11oBPwHl/bpacJ7xUcFY3Jt3CgcDt6d+XLvAJO8zMRsG9RcOm5MnxsyCsg==
+"@silverstripe/eslint-config@^1.0.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@silverstripe/eslint-config/-/eslint-config-1.1.0.tgz#3bf3d233b4ccfec4eeca362a621968ba2f70af59"
+  integrity sha512-7Y3zjAQzNyWceDDvd+cK0NdeI7MP0LJdL7JeF+JUBOmT14hOaBWvGrmcQLmYhZb2sTwh6JEgQI0+9ExVr/60nQ==
   dependencies:
     eslint "^8.26.0"
     eslint-config-airbnb "^19.0.4"
@@ -1274,10 +1274,10 @@
     eslint-plugin-react "^7.31.10"
     eslint-webpack-plugin "^3.2.0"
 
-"@silverstripe/webpack-config@^2.0.0-alpha5":
-  version "2.0.0-alpha6"
-  resolved "https://registry.yarnpkg.com/@silverstripe/webpack-config/-/webpack-config-2.0.0-alpha6.tgz#4a781f600344c3604169de08244ca11cacbd46f7"
-  integrity sha512-cPux01Z6EGwnSg5EezaJZ1S2x4ThfA3TbpTWTsqmW2jvr1VM/7Xu8B3j2HFH+2fNP0dvdmu+fScCD6VPNVQNWw==
+"@silverstripe/webpack-config@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@silverstripe/webpack-config/-/webpack-config-2.0.0.tgz#278a72a1adbc6fa2362497d60424c78fba58e8e1"
+  integrity sha512-m1qGRxlsdhWL567cWe7IZNBUCzeyg3T1Y9yY9Y6XClwAqlg1oIO9uLfvfauA4dbtECrzU5n1AkaaU6kMRtN6Aw==
   dependencies:
     "@babel/core" "^7.19.6"
     "@babel/preset-env" "^7.19.4"


### PR DESCRIPTION
We shouldn't be using the alpha anymore.
Lint rules were updated which required fixing some linting errors.

## Issue
- https://github.com/silverstripeltd/product-issues/issues/812