### PR TITLE
Add notes to BULK_MANAGER.md to make removeBulkAction and addBulkAction more obvious

### DIFF
--- a/docs/en/BULK_MANAGER.md
+++ b/docs/en/BULK_MANAGER.md
@@ -19,6 +19,15 @@ $config->getComponentByType('Colymba\\BulkManager\\BulkManager')->setConfig($ref
 The available configuration options are:
 * 'editableFields' : array of string referencing specific CMS fields available for editing
 
+## Removing and Adding actions
+To remove an action call removeBulkAction using the fully namespaced classname.
+```php
+    $gridField->getConfig()->getComponentByType('\Colymba\BulkManager\BulkManager')->removeBulkAction(\Colymba\BulkManager\BulkAction\UnlinkHandler::class);
+```
+To add an action:
+```php
+    $gridField->getConfig()->getComponentByType('\Colymba\BulkManager\BulkManager')->addBulkAction(\Colymba\BulkManager\BulkAction\UnlinkHandler::class);
+```
 ## Custom actions
 You can remove or add individual action or replace them all via `addBulkAction()` and `removeBulkAction()`
 


### PR DESCRIPTION
I got muddled up yesterday trying to specify the classname to add and remove actions.  Obvious once you know.  

Here I am fumbling around on SO.  
https://stackoverflow.com/questions/77781532/adding-and-removing-actions-from-silverstripe-bulkmanager/77786065#77786065

So some notes here to help others (me in a few months)