### PR TITLE
Fix incorrect CMS layout widths when bulk editing

### DIFF
--- a/src/BulkManager/BulkAction/EditHandler.php
+++ b/src/BulkManager/BulkAction/EditHandler.php
@@ -365,7 +365,7 @@ class EditHandler extends Handler
             'type' => 'Includes',
             'SilverStripe\\Admin\\LeftAndMain_EditForm',
         ]);
-        $form->addExtraClass('center cms-content');
+        $form->addExtraClass('center cms-content flexbox-area-grow');
         $form->setAttribute('data-pjax-fragment', 'CurrentForm Content');
 
         Requirements::javascript('colymba/gridfield-bulk-editing-tools:client/dist/js/main.js');


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description

The edit form is missing the necessary CSS class to ensure its width is consistent with other CMS sections.

Before:
<img width="1345" alt="Screenshot 2024-07-08 at 11 33 50" src="https://github.com/colymba/GridFieldBulkEditingTools/assets/1655548/13b831a2-4cb1-4f84-926d-c80afc0521f8">

After:
<img width="1354" alt="Screenshot 2024-07-08 at 11 33 57" src="https://github.com/colymba/GridFieldBulkEditingTools/assets/1655548/ab4fc4d5-f680-46e6-8f4c-9173be160240">

## Manual testing steps

Bulk edit something. My edit form includes an UploadField, not sure if that's relevant in triggering this, but it's definitely more noticeable at smaller screen sizes.

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- #294

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
