### PR TITLE
MNT Remove branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,6 @@
         "silverstripe/asset-admin": "^2"
     },
     "extra": {
-        "branch-alias": {
-            "dev-master": "4.x-dev"
-        },
         "expose": [
             "client/dist",
             "client/lang"


### PR DESCRIPTION
This needs to be merged all the way up through to `4` -> `5` -> `master`.

Removing branch alias as it's causing problems with tx-translator and is not best practice for supported modules.

## Issue
- https://github.com/silverstripe/.github/issues/289