### PR TITLE
fix multiple things in EditHandler

### DIFF
--- a/src/BulkManager/BulkAction/EditHandler.php
+++ b/src/BulkManager/BulkAction/EditHandler.php
@@ -107,7 +107,7 @@ class EditHandler extends Handler
      */
     public function Link($action = null)
     {
-        return Controller::join_links(parent::Link(), static::config()->url_segment, $action);
+        return Controller::join_links(parent::Link(), static::config()->get('url_segment'), $action);
     }
 
     /**

--- a/src/BulkManager/BulkAction/EditHandler.php
+++ b/src/BulkManager/BulkAction/EditHandler.php
@@ -24,7 +24,7 @@ class EditHandler extends Handler
     /**
      * URL segment used to call this handler
      * If none given, @BulkManager will fallback to the Unqualified class name
-     * 
+     *
      * @var string
      */
     private static $url_segment = 'edit';
@@ -53,14 +53,14 @@ class EditHandler extends Handler
 
     /**
      * Front-end label for this handler's action
-     * 
+     *
      * @var string
      */
     protected $label = 'Edit';
 
     /**
      * Front-end icon path for this handler's action.
-     * 
+     *
      * @var string
      */
     protected $icon = '';
@@ -68,22 +68,22 @@ class EditHandler extends Handler
     /**
      * Extra classes to add to the bulk action button for this handler
      * Can also be used to set the button font-icon e.g. font-icon-trash
-     * 
+     *
      * @var string
      */
     protected $buttonClasses = 'font-icon-edit';
-    
+
     /**
      * Whether this handler should be called via an XHR from the front-end
-     * 
+     *
      * @var boolean
      */
     protected $xhr = false;
-    
+
     /**
      * Set to true is this handler will destroy any data.
      * A warning and confirmation will be shown on the front-end.
-     * 
+     *
      * @var boolean
      */
     protected $destructive = false;
@@ -107,7 +107,7 @@ class EditHandler extends Handler
      */
     public function Link($action = null)
     {
-        return Controller::join_links(parent::Link(), $this->stat('url_segment'), $action);
+        return Controller::join_links(parent::Link(), static::config()->url_segment, $action);
     }
 
     /**
@@ -129,7 +129,7 @@ class EditHandler extends Handler
             FormAction::create('doSave', _t('GRIDFIELD_BULKMANAGER_EDIT_HANDLER.SAVE_BTN_LABEL', 'Save all'))
                 ->setAttribute('id', 'bulkEditingSaveBtn')
                 ->addExtraClass('btn btn-success')
-                ->setAttribute('data-icon', 'accept')
+                // ->setAttribute('data-icon', 'accept')
                 ->setUseButtonTag(true)
         );
 
@@ -137,7 +137,7 @@ class EditHandler extends Handler
             FormAction::create('Cancel', _t('GRIDFIELD_BULKMANAGER_EDIT_HANDLER.CANCEL_BTN_LABEL', 'Cancel'))
                 ->setAttribute('id', 'bulkEditingUpdateCancelBtn')
                 ->addExtraClass('btn btn-danger cms-panel-link')
-                ->setAttribute('data-icon', 'decline')
+                // ->setAttribute('data-icon', 'decline')
                 ->setAttribute('href', $one_level_up->Link)
                 ->setUseButtonTag(true)
                 ->setAttribute('src', '')//changes type to image so isn't hooked by default actions handlers
@@ -364,7 +364,7 @@ class EditHandler extends Handler
             'type' => 'Includes',
             'SilverStripe\\Admin\\LeftAndMain_EditForm',
         ]);
-        $form->addExtraClass('center cms-content');
+        $form->addExtraClass('center cms-content flexbox-area-grow fill-height');
         $form->setAttribute('data-pjax-fragment', 'CurrentForm Content');
 
         Requirements::javascript('colymba/gridfield-bulk-editing-tools:client/dist/js/main.js');

--- a/src/BulkManager/BulkAction/EditHandler.php
+++ b/src/BulkManager/BulkAction/EditHandler.php
@@ -128,19 +128,17 @@ class EditHandler extends Handler
         $actions->push(
             FormAction::create('doSave', _t('GRIDFIELD_BULKMANAGER_EDIT_HANDLER.SAVE_BTN_LABEL', 'Save all'))
                 ->setAttribute('id', 'bulkEditingSaveBtn')
-                ->addExtraClass('btn btn-success')
-                // ->setAttribute('data-icon', 'accept')
+                ->addExtraClass('btn btn-success font-icon font-icon-save')
                 ->setUseButtonTag(true)
         );
 
         $actions->push(
             FormAction::create('Cancel', _t('GRIDFIELD_BULKMANAGER_EDIT_HANDLER.CANCEL_BTN_LABEL', 'Cancel'))
                 ->setAttribute('id', 'bulkEditingUpdateCancelBtn')
-                ->addExtraClass('btn btn-danger cms-panel-link')
-                // ->setAttribute('data-icon', 'decline')
+                ->addExtraClass('btn btn-danger cms-panel-link font-icon font-icon-cancel')
                 ->setAttribute('href', $one_level_up->Link)
                 ->setUseButtonTag(true)
-                ->setAttribute('src', '')//changes type to image so isn't hooked by default actions handlers
+                ->setAttribute('src', '') //changes type to image so isn't hooked by default actions handlers
         );
 
         $recordList = $this->getRecordIDList();


### PR DESCRIPTION
## Description

This PR fixes multiple things in the EditHandler

- Fix layout like https://github.com/colymba/GridFieldBulkEditingTools/pull/295 + fix height for long forms
- Fix buttons (just commented for now...)
![image](https://github.com/user-attachments/assets/09563f6c-bc50-4f5a-8a73-4b889aedfe6a)
- Fix ->stat() method that doesn't exist anymore

## Manual testing steps

Edit multiple items and see that it works :)

## Issues


## Pull request checklist
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
