### PR TITLE
FIX Update HTML markup for bootstrap 5

### DIFF
--- a/templates/Colymba/BulkManager/BulkManagerButtons.ss
+++ b/templates/Colymba/BulkManager/BulkManagerButtons.ss
@@ -14,7 +14,7 @@
 
     </th>
     <th class="bulkSelectAll__container">
-        <label class="form-check-label">
+        <label class="form-check-label form-label">
             <input class="no-change-track bulkSelectAll form-check-input"
                 type="checkbox"
                 title="<%t GRIDFIELD_BULK_MANAGER.SELECT_ALL_LABEL '$Select.Label' %>"


### PR DESCRIPTION
See https://github.com/silverstripe/silverstripe-admin/pull/1889 which links to the specific upgrade guide entries for most changes made.

## Upgrade docs

- [boostrap](https://getbootstrap.com/docs/5.0/migration/)
- [reactstrap](https://reactstrap.github.io/?path=/story/home-upgrading--page)

## Issue
- https://github.com/silverstripe/.github/issues/332