### PR TITLE
TLN Update translations

### DIFF
--- a/client/src/lang/eo.json
+++ b/client/src/lang/eo.json
@@ -1,0 +1,5 @@
+{
+  "GRIDFIELD_BULK_UPLOAD.PROGRESS_INFO":               "Alŝutas %s dosiero(j)n. %s farita(j). %s eraro(j).",
+  "GRIDFIELD_BULK_MANAGER.BULKACTION_EMPTY_SELECT":    "Vi devas elekti almenaŭ unu rilordon.",
+  "GRIDFIELD_BULK_MANAGER.CONFIRM_DESTRUCTIVE_ACTION": "La datumoj perdiĝos porĉiame. Ĉu daŭrigu?"
+}

--- a/client/src/lang/nl.json
+++ b/client/src/lang/nl.json
@@ -1,5 +1,5 @@
 {
-    "GRIDFIELD_BULK_UPLOAD.PROGRESS_INFO": "Uploading %s file(s). %s done. %s error(s).",
-    "GRIDFIELD_BULK_MANAGER.BULKACTION_EMPTY_SELECT": "U moet minstens een item te selecteren.",
-    "GRIDFIELD_BULK_MANAGER.CONFIRM_DESTRUCTIVE_ACTION": "De gegevens zullen permanent verloren. Weet je zeker dat je de pagina wilt verlaten?"
+  "GRIDFIELD_BULK_UPLOAD.PROGRESS_INFO":               "%s bestand(en) geupload. %s verwerkt. %s fout(en).",
+  "GRIDFIELD_BULK_MANAGER.BULKACTION_EMPTY_SELECT":    "Selecteer tenminste één rij",
+  "GRIDFIELD_BULK_MANAGER.CONFIRM_DESTRUCTIVE_ACTION": "De data wordt permanent verwijderd. Weet je dit zeker?"
 }

--- a/client/src/lang/sk.json
+++ b/client/src/lang/sk.json
@@ -1,5 +1,5 @@
 {
-    "GRIDFIELD_BULK_UPLOAD.PROGRESS_INFO": "Nahrávam %s súbor(y/ov). %s hotovo. %s chyb(a/y).",
-    "GRIDFIELD_BULK_MANAGER.BULKACTION_EMPTY_SELECT": "Musíte vybrať aspoň jednu položku.",
-    "GRIDFIELD_BULK_MANAGER.CONFIRM_DESTRUCTIVE_ACTION": "Dáta budú nenávratne stratené. Chcete pokračovať?"
+  "GRIDFIELD_BULK_UPLOAD.PROGRESS_INFO":               "Nahrávam %s súbor(y). %s hotovo. %s chyba(y).",
+  "GRIDFIELD_BULK_MANAGER.BULKACTION_EMPTY_SELECT":    "Musíte vybrať aspoň jeden záznam.",
+  "GRIDFIELD_BULK_MANAGER.CONFIRM_DESTRUCTIVE_ACTION": "Dáta sa permanentne stratia. Chcete pokračovať?"
 }

--- a/client/src/lang/sl.json
+++ b/client/src/lang/sl.json
@@ -1,0 +1,5 @@
+{
+  "GRIDFIELD_BULK_UPLOAD.PROGRESS_INFO":               "V teku je prenos %s datotek(e). %s zaključenih. %s napak(e).",
+  "GRIDFIELD_BULK_MANAGER.BULKACTION_EMPTY_SELECT":    "Izbrati morate vsaj en zapis.",
+  "GRIDFIELD_BULK_MANAGER.CONFIRM_DESTRUCTIVE_ACTION": "Želite dokončno izbrisati podatke?"
+}

--- a/client/src/lang/sv.json
+++ b/client/src/lang/sv.json
@@ -1,0 +1,5 @@
+{
+  "GRIDFIELD_BULK_UPLOAD.PROGRESS_INFO":               "Uploading %s file(s). %s done. %s error(s).",
+  "GRIDFIELD_BULK_MANAGER.BULKACTION_EMPTY_SELECT":    "Du måst välja åtmistone en rad.",
+  "GRIDFIELD_BULK_MANAGER.CONFIRM_DESTRUCTIVE_ACTION": "Denna data kommer att förloras permanent. Är du säker på att du vill fortsätta?"
+}


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/365

I'm not sure why the translations are indented the way they are, I could find anything in the settings for the repo in transifex