### PR TITLE
FIX Fix label to rely on localisation done in PHP code

### DIFF
--- a/templates/Colymba/BulkManager/BulkManagerButtons.ss
+++ b/templates/Colymba/BulkManager/BulkManagerButtons.ss
@@ -17,7 +17,7 @@
         <label class="form-check-label form-label">
             <input class="no-change-track bulkSelectAll form-check-input"
                 type="checkbox"
-                title="<%t GRIDFIELD_BULK_MANAGER.SELECT_ALL_LABEL '$Select.Label' %>"
+                title="$Select.Label"
                 name="toggleSelectAll" />
         </label>
     </th>


### PR DESCRIPTION
Fixes localisation for select all label as discovered by https://github.com/silverstripe/silverstripe-gridfield-bulk-editing-tools/pull/329#discussion_r2085924344

The label localisation is already done in PHP: https://github.com/silverstripe/silverstripe-gridfield-bulk-editing-tools/blob/5.0/src/BulkManager/BulkManager.php#L302-L304

## Issue

- https://github.com/silverstripe/.github/issues/400